### PR TITLE
Fix documentation for compatibility with Texinfo 5

### DIFF
--- a/doc/ffi.texi
+++ b/doc/ffi.texi
@@ -752,8 +752,8 @@ object.  There are situations where the latter data structures are
 unsafe to use; @value{PRJNAME} discharges on the application the
 responsibility of using or not using such structures.
 
-@table @meta
-@item fields-clause
+@table @var
+@item ?fields-clause
 This clause is @strong{optional}.  It must have one of the forms:
 
 @example
@@ -766,7 +766,7 @@ where @code{fields} is the auxiliary keyword exported by
 @rsixlibrary{rnrs} and the @var{field-id} are field name identifiers.
 The listed fields become normal fields of the defined structure.
 
-@item destructor-clause
+@item ?destructor-clause
 It must have one of the forms:
 
 @example
@@ -784,7 +784,7 @@ referenced destructor function is applied to the Scheme data struct; its
 responsibility is to extract the pointer object and apply to it whatever
 finalisation procedure the foreign library provides.
 
-@item collector-clause
+@item ?collector-clause
 It must have one of the forms:
 
 @example
@@ -813,7 +813,7 @@ unregisters itself from the collection in the instance of type
 @meta{collector-id}.
 @end itemize
 
-@item collected-clause
+@item ?collected-clause
 These clauses are optional and can be present in any number; when used,
 they must have the form:
 

--- a/doc/iklib.texi
+++ b/doc/iklib.texi
@@ -13,27 +13,27 @@
 In addition to the libraries listed in the @rnrs{6} standard,
 @value{PRJNAME} offers more libraries which provide additional features:
 
-@table @library
-@item ikarus
+@table @code
+@item (ikarus)
 It is a composite library, it exports a superset of all the supported
 bindings of @rnrs{6}.
 
-@item vicare
+@item (vicare)
 It exports the same bindings of @library{ikarus}.
 
-@item vicare language-extensions
+@item (vicare language-extensions)
 It exports all the bindings exported by @library{vicare} that are
 @strong{not} exported by @library{rnrs (6)}.
 
-@item vicare platform constants
+@item (vicare platform constants)
 Exports one syntax identifier binding for each platform constant that
 makes sense to access from Scheme.
 
-@item vicare platform utilities
+@item (vicare platform utilities)
 Defines helper functions to deal with platform specific issues;
 @ref{platform} for details.
 
-@item vicare platform features
+@item (vicare platform features)
 @cindex Library @library{vicare platform features}
 @cindex @library{vicare platform features}, library
 Exports an identifier syntax for every @code{HAVE_} symbol defined by

--- a/doc/lang.texi
+++ b/doc/lang.texi
@@ -2060,7 +2060,7 @@ The empty @code{or} fails.
 @result{} #t
 @end example
 
-@itemx (not @meta{pattern})
+@item (not @meta{pattern})
 Matches if the subpattern @meta{pattern} does @strong{not} match the
 input expression.  The empty not fails.  The empty @code{not} pattern is
 a syntax error; the @code{not} pattern with multiple subpatterns is a

--- a/doc/libs.texi
+++ b/doc/libs.texi
@@ -2901,8 +2901,8 @@ logic.
 
 The input arguments are:
 
-@table @meta
-@item definer
+@table @var
+@item ?definer
 It must be an identifier.  It is bound to the generated syntax
 definition; such syntax is used as follows:
 
@@ -2915,12 +2915,12 @@ where: @meta{device-logic} is the identifier bound to the device logic
 syntax; the @meta{operator-name} are identifiers among the public
 operator function names.
 
-@item ch
+@item ?ch
 It must be an identifier.  When a character is successfully extracted
 from the input device, it is bound to this identifier and made available
 to the operator clauses.
 
-@item next
+@item ?next
 It must be an identifier.  The device logic rule
 @code{:generate-end-of-input-or-char-tests} must bind it to a syntax;
 such syntax must expand to a tail--call to an operator processing the
@@ -2943,7 +2943,7 @@ where: @meta{device-arg} are the arguments representing the input device
 state; @meta{operator-arg} are the arguments representing the parser
 state as specified in the @meta{operator-spec}.
 
-@item fail
+@item ?fail
 It must be an identifier.  The device logic rule
 @code{:generate-end-of-input-or-char-tests} must bind it to a syntax;
 such syntax is used to handle parsing errors detected by the operator
@@ -2959,8 +2959,8 @@ Each @meta{operator-spec} must have the form:
 @noindent
 where:
 
-@table @meta
-@item operator-name
+@table @var
+@item ?operator-name
 Must be an identifier.  It is bound to a generated operator function.
 
 There is no difference in the way public operators and private ones are
@@ -2968,11 +2968,11 @@ specified; the public operators names are listed in the concrete parser
 definition.  An operator can be public in a concrete parser and private
 in another concrete parser.
 
-@item operator-arg
+@item ?operator-arg
 Must be identifiers bound to the formal arguments associated to the
 parser state.
 
-@item operator-clause
+@item ?operator-clause
 Are symbolic expressions specifying the input accepted by the operator.
 @end table
 

--- a/doc/posix.texi
+++ b/doc/posix.texi
@@ -5694,9 +5694,9 @@ posix}; this section lists some of them along with reasons for not
 interface them.  This is not the last word: if good reasons arise to
 interface some of the functions, they will.
 
-@table @cfunc
-@item popen
-@itemx pclose
+@table @code
+@item popen()
+@itemx pclose()
 @findex popen
 @findex pclose
 There seems to be no real advantage (in a Scheme @api{}) to use these

--- a/doc/srfi-cond-expand.texi
+++ b/doc/srfi-cond-expand.texi
@@ -560,7 +560,7 @@ The Scheme implementation is @value{PRJNAME}.
 @item posix
 The program is running under a @posix{} system.
 
-@itemx linux
+@item linux
 @itemx solaris
 @itemx darwin
 @itemx bsd

--- a/doc/srfi-eager-comp.texi
+++ b/doc/srfi-eager-comp.texi
@@ -1647,7 +1647,7 @@ other macros.  The MWL--concept, and its implementation, were most
 influential for this @srfi{}.
 
 Another related mechanism is the library of streams recently submitted
-by Phil L. Bewig as @srfi{40} (superseded by @srfi{41}).  The library
+by Phil L. Bewig as @ansrfi{40} (superseded by @ansrfi{41}).  The library
 contains a data type to represent even streams (both car and cdr
 potentially delayed) and defines procedures for manipulating these
 streams.  Moreover, the macro @func{stream-of} defines a lazy
@@ -1669,8 +1669,8 @@ created his library to support the stream paradigm in Scheme, inspired
 by the work done for Haskell and other lazy languages, and intrigued by
 the beauty of programming with infinite streams.  My work only aims at a
 convenient way of expressing frequent patterns of loops in a compact
-way.  For what it is worth, section @srfi{40}-ec contains a suggestion
-for extending the eager comprehension mechanism for @srfi{41} streams.
+way.  For what it is worth, section @ansrfi{40}-ec contains a suggestion
+for extending the eager comprehension mechanism for @ansrfi{41} streams.
 
 Phil's work on streams and lazy comprehensions in Scheme triggered Eli
 Barzilay to implement a library of eager comprehensions for

--- a/doc/srfi-err5rs-records.texi
+++ b/doc/srfi-err5rs-records.texi
@@ -430,33 +430,33 @@ corresponding procedure of the @rnrs{6} procedural layer.)
 
 All implementations of @ansrfi{99} must provide the following libraries:
 
-@table @library
-@item srfi :99
+@table @code
+@item (srfi :99)
 Alias for @library{srfi :99 records}.
 
-@item srfi :99 records
+@item (srfi :99 records)
 Composite of the next three.
 
-@item srfi :99 records procedural
-@itemx srfi :99 records inspection
-@itemx srfi :99 records syntactic
+@item (srfi :99 records procedural)
+@itemx (srfi :99 records inspection)
+@itemx (srfi :99 records syntactic)
 One library for each layer.
 @end table
 
 Implementations of @acronym{ERR5RS} should provide the following aliases
 as well:
 
-@table @library
-@item err5rs records
+@table @code
+@item (err5rs records)
 Alias for @library{srfi :99 records}.
 
-@item err5rs records procedural
+@item (err5rs records procedural)
 Alias for @library{srfi :99 records procedural}.
 
-@item err5rs records inspection
+@item (err5rs records inspection)
 Alias for @library{srfi :99 records inspection}.
 
-@item err5rs records syntactic
+@item (err5rs records syntactic)
 Alias for @library{srfi :99 records syntactic}.
 @end table
 

--- a/doc/srfi-error-reporting.texi
+++ b/doc/srfi-error-reporting.texi
@@ -2,7 +2,7 @@
 @section @ansrfi{23} error reporting mechanism
 
 
-@cindex @srfi{23} error reporting mechanism
+@cindex @ansrfi{23} error reporting mechanism
 @cindex @library{srfi :23}, library
 @cindex @library{srfi :23 error}, library
 @cindex Library @library{srfi :23}

--- a/doc/srfi-lightweight-testing.texi
+++ b/doc/srfi-lightweight-testing.texi
@@ -131,12 +131,12 @@ development----of @srfi{}s.
 Although it is extremely straightforward, the origin of the particular
 mechanism described here is the @file{examples.scm} file accompanying
 the reference implementation of @ansrfi{42}.  The same mechanism has been
-reimplemented for the reference implementation of @srfi{67}, and a
+reimplemented for the reference implementation of @ansrfi{67}, and a
 simplified version is yet again found in the reference implementation of
 @ansrfi{77}.
 
 The mechanism in this @srfi{} does not replace more sophisticated
-approaches to unit testing, like @srfi{64} or SchemeUnit.  These
+approaches to unit testing, like @ansrfi{64} or SchemeUnit.  These
 systems provide more control of the testing, separate the definition of
 a test, its execution, and its reports, and provide several other
 features.
@@ -234,7 +234,7 @@ list the relevant free variables of @var{expr} (see examples) that you
 want to have printed.
 
 A @var{qualifier} is any qualifier of an eager comprehension as
-specified in @srfi{42}.
+specified in @ansrfi{42}.
 
 Examples:
 

--- a/doc/srfi-vectors.texi
+++ b/doc/srfi-vectors.texi
@@ -73,7 +73,7 @@ be contained in a module/structure/package/library/unit called
 
 
 @rnrs{5} provides very few list--processing procedures, for which reason
-@srfi{1} exists.  However, @rnrs{5} provides even fewer vector
+@ansrfi{1} exists.  However, @rnrs{5} provides even fewer vector
 operations; while it provides mapping, appending, et cetera operations
 for lists, it specifies only nine vector manipulation operations:
 
@@ -92,7 +92,7 @@ reason, this @srfi{} is proposed.
 
 It should be noted that no vector sorting procedures are provided by
 this @srfi{}, because there already is a @srfi{} for such a purpose,
-@srfi{32}, which includes routines for sorting not only vectors but also
+@ansrfi{32}, which includes routines for sorting not only vectors but also
 lists.
 
 @c page
@@ -902,26 +902,26 @@ can be found at:
 @center @url{http://srfi.schemers.org/}
 
 @noindent
-@emph{@srfi{1}: List Library}.  A @srfi{} of list processing procedures,
+@emph{@ansrfi{1}: List Library}.  A @srfi{} of list processing procedures,
 written by Olin Shivers.
 
 @center @url{http://srfi.schemers.org/srfi-1/}
 
 @noindent
-@emph{@srfi{13}: String Library}.  A @srfi{} of string processing
+@emph{@ansrfi{13}: String Library}.  A @srfi{} of string processing
 procedures, written by Olin Shivers.
 
 @center @url{http://srfi.schemers.org/srfi-13/}
 
 @noindent
-@emph{@srfi{23}: Error Reporting Mechanism}.  A @srfi{} that defines a
+@emph{@ansrfi{23}: Error Reporting Mechanism}.  A @srfi{} that defines a
 new primitive (error) for reporting that an error occurred, written by
 Stephan Houben.
 
 @center @url{http://srfi.schemers.org/srfi-23/}
 
 @noindent
-@emph{@srfi{32}: Sort Libraries (draft)}.  A @srfi{} of list and vector
+@emph{@ansrfi{32}: Sort Libraries (draft)}.  A @srfi{} of list and vector
 sorting routines, written by Olin Shivers.
 
 @center @url{http://srfi.schemers.org/srfi-32/}


### PR DESCRIPTION
The Ikarus/Vicare documentation build is broken with the new 5.x Perl rewrite of Texinfo, now in e.g. Debian unstable or — for me — Arch Linux. The issues include `@item` vs. `@itemx` and `@srfi{}` vs. `@ansrfi{N}` (fixed by using the appropriate command) and `@table` refusing to accept macros as item formatters (alas, only fixed by hardcoding the behaviour of `@table @library`, `@table @meta` and `@table @cfunc` where they were used).
