### PR TITLE
Stop makeinfo 5.1 from erroring out with "@itemx must follow @item".

### DIFF
--- a/doc/libs-bytevectors.texi
+++ b/doc/libs-bytevectors.texi
@@ -804,7 +804,7 @@ An unquoted list holding the bytevector and the past index, with
 auxiliary syntaxes @code{view} and @code{past}: it selects the subvector
 from zero to the selected past index.
 
-@itemx (view @meta{bytevector} (start @meta{start-index}) (past @meta{past-index}))
+@item (view @meta{bytevector} (start @meta{start-index}) (past @meta{past-index}))
 An unquoted list holding the bytevector, the start index and the past
 index, with auxiliary syntaxes @code{view}, @code{start} and
 @code{past}: it selects the subvector between the start and past

--- a/doc/libs-strings.texi
+++ b/doc/libs-strings.texi
@@ -357,7 +357,7 @@ An unquoted list holding the string and the past index, with auxiliary
 syntaxes @code{view} and @code{past}: it selects the substring from zero
 to the selected past index.
 
-@itemx (view @meta{string} (start @meta{start-index}) (past @meta{past-index}))
+@item (view @meta{string} (start @meta{start-index}) (past @meta{past-index}))
 An unquoted list holding the string, the start index and the past index,
 with auxiliary syntaxes @code{view}, @code{start} and @code{past}: it
 selects the substring between the start and past indexes.

--- a/doc/libs-vectors.texi
+++ b/doc/libs-vectors.texi
@@ -289,7 +289,7 @@ The vector itself or an unquoted list holding the vector itself,
 prefixed by the @code{view} auxiliary syntax: it selects the whole
 vector.
 
-@itemx (view @meta{vector} (start @meta{start-index}))
+@item (view @meta{vector} (start @meta{start-index}))
 An unquoted list holding the vector and the start index, with auxiliary
 syntaxes @code{view} and @code{start}: it selects the subvector from the
 start index to the end.
@@ -299,7 +299,7 @@ An unquoted list holding the vector and the past index, with auxiliary
 syntaxes @code{view} and @code{past}: it selects the subvector from zero
 to the selected past index.
 
-@itemx (view @meta{vector} (start @meta{start-index}) (past @meta{past-index}))
+@item (view @meta{vector} (start @meta{start-index}) (past @meta{past-index}))
 An unquoted list holding the vector, the start index and the past index,
 with auxiliary syntaxes @code{view}, @code{start} and @code{past}: it
 selects the subvector between the start and past indexes.


### PR DESCRIPTION
These were the errors.

 ./vectors.texi:292: @itemx must follow @item
 ./vectors.texi:302: @itemx must follow @item
 ./strings.texi:360: @itemx must follow @item
 ./bytevectors.texi:807: @itemx must follow @item

The cause was that this is legal:

 @item foo
 @itemx bar

while this is illegal:

 @item foo

 @itemx bar

as is this:

 @item foo
 text
 @itemx bar
 more text

and this:

 @item foo
 text

 @itemx bar
 more text
