### PR TITLE
autogen.sh now respects the LIBTOOLIZE environment variable.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,9 +4,11 @@
 
 export PATH=/bin:/usr/local/bin:/usr/bin:$PATH
 
+LIBTOOLIZE=${LIBTOOLIZE:=libtoolize}
+
 set -xe
 test -d autotools		|| mkdir autotools
-test -f autotools/libtool.m4	|| libtoolize
+test -f autotools/libtool.m4	|| ${LIBTOOLIZE}
 autoreconf --warnings=all --install --verbose "$@"
 
 ### end of file


### PR DESCRIPTION
On OSX machines, you're generally better off using `glibtoolize` instead. This lets you set this with the `LIBTOOLIZE` environment variable.
