### PR TITLE
Stat typo, OS X fixes?

### DIFF
--- a/src/ikarus-linux.c
+++ b/src/ikarus-linux.c
@@ -853,7 +853,7 @@ ikrt_linux_ether_aton (ikptr_t s_addr_str, ikptr_t s_addr_len, ikpcb_t * pcb)
 ikptr_t
 ikrt_linux_ether_ntoa_r (ikptr_t s_ether_addr_bv, ikpcb_t * pcb)
 {
-#ifdef HAVE_ETHER_NTOA
+#ifdef HAVE_ETHER_NTOA_R
   const struct ether_addr *	addr	= IK_BYTEVECTOR_DATA_VOIDP(s_ether_addr_bv);
   char				buffer[64];
   char *			rv;
@@ -866,7 +866,7 @@ ikrt_linux_ether_ntoa_r (ikptr_t s_ether_addr_bv, ikpcb_t * pcb)
 ikptr_t
 ikrt_linux_ether_aton_r (ikptr_t s_addr_str, ikptr_t s_addr_len, ikpcb_t * pcb)
 {
-#ifdef HAVE_ETHER_ATON
+#ifdef HAVE_ETHER_ATON_R
   const char *		name	= IK_GENERALISED_C_STRING(s_addr_str);
   struct ether_addr	buffer;
   struct ether_addr *	rv;

--- a/src/ikarus-posix.c
+++ b/src/ikarus-posix.c
@@ -926,7 +926,7 @@ ikrt_posix_file_ctime (ikptr_t s_pathname, ikptr_t s_vector, ikpcb_t* pcb)
     ts.tv_sec  = S.st_ctime;
     ts.tv_nsec = S.st_ctimensec;
 #else
-    ts.tv_sec  = s.st_ctime;
+    ts.tv_sec  = S.st_ctime;
     ts.tv_nsec = 0;
 #endif
     return timespec_vector(&ts, s_vector, pcb);
@@ -955,7 +955,7 @@ ikrt_posix_file_mtime (ikptr_t s_pathname, ikptr_t s_vector, ikpcb_t* pcb)
     ts.tv_sec  = S.st_mtime;
     ts.tv_nsec = S.st_mtimensec;
 #else
-    ts.tv_sec  = s.st_mtime;
+    ts.tv_sec  = S.st_mtime;
     ts.tv_nsec = 0;
 #endif
     return timespec_vector(&ts, s_vector, pcb);
@@ -984,7 +984,7 @@ ikrt_posix_file_atime (ikptr_t s_pathname, ikptr_t s_vector, ikpcb_t* pcb)
     ts.tv_sec  = S.st_atime;
     ts.tv_nsec = S.st_atimensec;
 #else
-    ts.tv_sec  = s.st_atime;
+    ts.tv_sec  = S.st_atime;
     ts.tv_nsec = 0;
 #endif
     return timespec_vector(&ts, s_vector, pcb);


### PR DESCRIPTION
* struct stat S.
* ether_*() are undefined on OS X.
